### PR TITLE
Adding software to compare pangenome graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@
 * [vg validate](https://github.com/vgteam/vg)
 * [odgi validate](https://github.com/pangenome/odgi)
 
+# Pangenome comparison
+
+* [junctions](https://github.com/urbanslug/junctions) Pangenome comparison using elastic-degenerate strings.
+* [rs-pancat-compare](https://github.com/dubssieg/rs-pancat-compare) Pairwise pangenome graph comparison by the computation of a segmentation edit distance.
+
 # File formats
 
 * [GFA](http://gfa-spec.github.io/GFA-spec/GFA1.html) An assembly interchange format read by both vg and odgi :rocket:
@@ -139,8 +144,6 @@
 * [GRAFIMO](https://github.com/pinellolab/GRAFIMO) GRAph-based Finding of Individual Motif Occurrences using vg
 * [rs-gfa](https://github.com/chfi/rs-gfa) A GFA parser in Rust.
 * [ropebwt3](https://github.com/lh3/ropebwt3) Can construct and align sequences against huge TB scale references and retrieve haplotypes.
-* [junctions](https://github.com/urbanslug/junctions) Pangenome comparison using elastic-degenerate strings.
-* [rs-pancat-compare](https://github.com/dubssieg/rs-pancat-compare) Pairwise pangenome graph comparison by the computation of a segmentation edit distance.
 
 
 # kmer based approaches

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@
 * [GRAFIMO](https://github.com/pinellolab/GRAFIMO) GRAph-based Finding of Individual Motif Occurrences using vg
 * [rs-gfa](https://github.com/chfi/rs-gfa) A GFA parser in Rust.
 * [ropebwt3](https://github.com/lh3/ropebwt3) Can construct and align sequences against huge TB scale references and retrieve haplotypes.
+* [junctions](https://github.com/urbanslug/junctions) Pangenome comparison using elastic-degenerate strings.
+* [rs-pancat-compare](https://github.com/dubssieg/rs-pancat-compare) Pairwise pangenome graph comparison by the computation of a segmentation edit distance.
 
 
 # kmer based approaches


### PR DESCRIPTION
Hello,

In this PR i propose the addition of two tools to the list:
- `junctions` that was published [at the end of September this year](https://www.frontiersin.org/journals/bioinformatics/articles/10.3389/fbinf.2024.1397036/full)
- `rs-pancat-compare` (draft paper)
Thes two tools compute distances between pangenome, from two different perspectives : the first one relies on ED-strings (compares the content, what is common or not in the two graphs) and the second investiguates the segmentation (how a smae genome is splitted differently in the two graphs).