### PR TITLE
Add PangenomeX CNV caller to the list of tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ A new section for microbial genomes has also been added, these tools may not sca
 * [BayesTyper](https://github.com/bioinformatics-centre/BayesTyper) ([paper](https://pubmed.ncbi.nlm.nih.gov/29915429/)) Accurate genotyping across variant classes and lengths using variant graphs
 * [Swave](https://github.com/songbowang125/Swave) ([preprint](https://www.biorxiv.org/content/10.1101/2025.07.06.663386v1.abstract)) Detect SVs from a (minigraph) pangenome graph (free for non-commercial use)
 * [APAV](https://github.com/SJTU-CGM/APAV) ([paper](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1013288)) A pangenome PAV detection and visualization toolkit in Perl and R.
-
+* [PangenomeX](https://github.com/Nevermore233/PangenomeX) ([paper](https://academic.oup.com/bib/article/26/5/bbaf550/8293245?login=true)) "Pangenome" CNV calller in python. (Builds its own pangenome)
 
 # Transcriptome analysis
 


### PR DESCRIPTION
Hello,

Just found this tool. 
Seems like it builds its own pangenome based on read depth differences to catch CNV.
Looking at the code I wouldn't say it's interoperable.

Is it worth to add it here ?

Warm regards.